### PR TITLE
Fix missing comma in TestAdd function

### DIFF
--- a/tips.md
+++ b/tips.md
@@ -5197,7 +5197,7 @@ func TestAdd(t *testing.T) {
         a, b, expected int
     }{
         {"2 positives", 1, 2, 3},
-        {"positive & zero", 5, 0, 5}
+        {"positive & zero", 5, 0, 5},
         {"2 negatives", -1, -2, -3},
         {"negative & positive", -5, 10, 5},
     }


### PR DESCRIPTION
This pull request fixes a minor syntax error in the `TestAdd` function. A comma (,) was missing after one of the test case struct declarations, which would cause compilation errors.

**Specific Change:**

- Added a comma (,) after `"positive & zero", 5, 0, 5` within the `testCases` slice.
